### PR TITLE
Scala warnings: use chisel3.IO instead of deprecated chisel3.experimental.IO

### DIFF
--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -2,7 +2,6 @@ package icenet
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.IO
 import freechips.rocketchip.subsystem.{BaseSubsystem, FBUS, PBUS, TLBusWrapperLocation}
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._


### PR DESCRIPTION
## Purpose

### Why is this change being made?
fix these Scala compile warnings:
```
[warn] icenet/src/main/scala/NIC.scala:530:24: method apply in object IO is deprecated (since Chisel 3.5): chisel3.experimental.IO is deprecated, use chisel3.IO instead
[warn]         val inner_io = IO(new NICIOvonly).suggestName("nic")
[warn]                        ^
[warn] icenet/src/main/scala/NIC.scala:537:22: method apply in object IO is deprecated (since Chisel 3.5): chisel3.experimental.IO is deprecated, use chisel3.IO instead
[warn]       val outer_io = IO(new ClockedIO(new NICIOvonly)).suggestName("nic")
[warn]                      ^
```

### Type of change
- Paying Off Technical Debt


## Scope

### What was changed?
remove import `chisel3.experimental.IO`

### Breaking changes to APIs or data formats
<!-- Describe any changes to interfaces and steps for migrating. -->

### What should be reviewed
<!-- @-mention individual reviewers and indicate what you expect from their review -->


## Risk

### What are the potential consequences of this change?
<!-- Describe any positive or negative effects these changes may have on build health or people's workflows -->

<!-- Describe the impact of this change on build times, test run times, and license usage -->

### How this was tested or validated
`make prelude`

### Technical debt added
there are many more warnings we can take down for spring cleaning