### PR TITLE
Scala warnings: call method 'fire' without parentheses

### DIFF
--- a/src/main/scala/Aligner.scala
+++ b/src/main/scala/Aligner.scala
@@ -41,17 +41,17 @@ class Aligner(dataBits: Int) extends Module {
   io.in.ready := full_nbytes < dataBytes.U ||
                  (io.out.ready && !last)
 
-  when (io.in.fire() && io.out.fire()) {
+  when (io.in.fire && io.out.fire) {
     data := full_data >> dataBits.U
     keep := full_keep >> dataBytes.U
     last := io.in.bits.last && !fwd_last
     nbytes := Mux(fwd_last, 0.U, full_nbytes - dataBytes.U)
-  } .elsewhen (io.in.fire()) {
+  } .elsewhen (io.in.fire) {
     data := full_data
     keep := full_keep
     last := io.in.bits.last
     nbytes := full_nbytes
-  } .elsewhen (io.out.fire()) {
+  } .elsewhen (io.out.fire) {
     data := 0.U
     keep := 0.U
     last := false.B
@@ -88,8 +88,8 @@ class AlignerTest extends UnitTest {
 
   val aligner = Module(new Aligner(NET_IF_WIDTH))
 
-  val (inIdx, inDone) = Counter(aligner.io.in.fire(), inData.size)
-  val (outIdx, outDone) = Counter(aligner.io.out.fire(), outData.size)
+  val (inIdx, inDone) = Counter(aligner.io.in.fire, inData.size)
+  val (outIdx, outDone) = Counter(aligner.io.out.fire, outData.size)
 
   aligner.io.in.valid := sending
   aligner.io.in.bits.data := inData(inIdx)

--- a/src/main/scala/Buffer.scala
+++ b/src/main/scala/Buffer.scala
@@ -174,7 +174,7 @@ class NetworkPacketBuffer[T <: Data](
   val customDrop = dropChecks.map(check => check(
                                     header,
                                     io.stream.in.bits,
-                                    io.stream.in.fire() && headerValid))
+                                    io.stream.in.fire && headerValid))
                              .foldLeft(false.B)(_ || _)
   val startDropping =
     (inPhase === outPhase && hasPackets) ||
@@ -183,12 +183,12 @@ class NetworkPacketBuffer[T <: Data](
   val capDrop = startDropping || inDrop
   val nonCapDrop = !headerValid || customDrop
   val anyDrop = capDrop || nonCapDrop
-  val dropLastFire = anyDrop && io.stream.in.fire() && io.stream.in.bits.last
+  val dropLastFire = anyDrop && io.stream.in.fire && io.stream.in.bits.last
 
   // io.free indicates the number of flits being freed up on a cycle
   io.free := ren + Mux(dropLastFire, inIdx + 1.U, 0.U)
 
-  when (io.stream.out.fire()) { outValidReg := false.B }
+  when (io.stream.out.fire) { outValidReg := false.B }
 
   when (readLen) { lengthKnown := true.B }
 
@@ -210,7 +210,7 @@ class NetworkPacketBuffer[T <: Data](
 
   when (ren =/= wen) { maybeFull := wen }
 
-  when (io.stream.in.fire()) {
+  when (io.stream.in.fire) {
     when (inIdx === 0.U) { startHead := bufHead }
     when (startDropping) { inDrop := true.B }
     wen := !startDropping && !inDrop
@@ -313,7 +313,7 @@ class NetworkPacketBufferTest extends UnitTest(100000) {
     state := s_input
   }
 
-  when (buffer.io.stream.in.fire()) {
+  when (buffer.io.stream.in.fire) {
     inIdx := inIdx + 1.U
     when (buffer.io.stream.in.bits.last) {
       inIdx := 0.U
@@ -322,7 +322,7 @@ class NetworkPacketBufferTest extends UnitTest(100000) {
     }
   }
 
-  when (buffer.io.stream.out.fire()) {
+  when (buffer.io.stream.out.fire) {
     outIdx := outIdx + 1.U
     when (buffer.io.stream.out.bits.last) {
       outIdx := 0.U
@@ -388,9 +388,9 @@ class ReservationBuffer(nXacts: Int, nWords: Int, dataBits: Int) extends Module 
   val ren = (!occupied || io.out.ready) && (bufValid >> tail)(0)
 
   count := count +
-              Mux(io.alloc.fire(), io.alloc.bits.count, 0.U) -
-              Mux(io.out.fire(), 1.U, 0.U)
-  bufValid := (bufValid | Mux(io.in.fire(), UIntToOH(curXactHead), 0.U)) &
+              Mux(io.alloc.fire, io.alloc.bits.count, 0.U) -
+              Mux(io.out.fire, 1.U, 0.U)
+  bufValid := (bufValid | Mux(io.in.fire, UIntToOH(curXactHead), 0.U)) &
                          ~Mux(ren, UIntToOH(tail), 0.U)
 
   io.alloc.ready := !full
@@ -398,22 +398,22 @@ class ReservationBuffer(nXacts: Int, nWords: Int, dataBits: Int) extends Module 
   io.out.valid := occupied
   io.out.bits := buffer.io.read.data
 
-  buffer.io.write.en := io.in.fire()
+  buffer.io.write.en := io.in.fire
   buffer.io.write.addr := curXactHead
   buffer.io.write.data := io.in.bits.data
   buffer.io.read.en := ren
   buffer.io.read.addr := tail
 
-  when (io.alloc.fire()) {
+  when (io.alloc.fire) {
     xactHeads(io.alloc.bits.id) := head
     head := incWrap(head, io.alloc.bits.count)
   }
 
-  when (io.in.fire()) {
+  when (io.in.fire) {
     xactHeads(io.in.bits.id) := incWrap(curXactHead, 1.U)
   }
 
-  when (io.out.fire()) { occupied := false.B }
+  when (io.out.fire) { occupied := false.B }
 
   when (ren) {
     occupied := true.B
@@ -429,8 +429,8 @@ class PacketCollectionBuffer(bufWords: Int) extends Module {
 
   val queue = Module(new Queue(new StreamChannel(NET_IF_WIDTH), bufWords))
   val pktCount = TwoWayCounter(
-    queue.io.enq.fire() && queue.io.enq.bits.last,
-    queue.io.deq.fire() && queue.io.deq.bits.last,
+    queue.io.enq.fire && queue.io.enq.bits.last,
+    queue.io.deq.fire && queue.io.deq.bits.last,
     maxPackets)
   val canDequeue = pktCount > 0.U
 

--- a/src/main/scala/Checksum.scala
+++ b/src/main/scala/Checksum.scala
@@ -50,7 +50,7 @@ class ChecksumCalc(dataBits: Int) extends Module {
   io.result.valid := state === s_result
   io.result.bits := csum(15, 0)
 
-  when (io.req.fire()) {
+  when (io.req.fire) {
     check := io.req.bits.check
     start := io.req.bits.start
     csum := io.req.bits.init
@@ -58,7 +58,7 @@ class ChecksumCalc(dataBits: Int) extends Module {
     state := s_stream
   }
 
-  when (io.stream.in.fire()) {
+  when (io.stream.in.fire) {
     when (check) {
       csum := csum + sumData
       startPos := nextStartPos
@@ -81,7 +81,7 @@ class ChecksumCalc(dataBits: Int) extends Module {
     }
   }
 
-  when (io.result.fire()) { state := s_req }
+  when (io.result.fire) { state := s_req }
 }
 
 class ChecksumRewrite(dataBits: Int, nBufFlits: Int) extends Module {
@@ -127,19 +127,19 @@ class ChecksumRewrite(dataBits: Int, nBufFlits: Int) extends Module {
   val s_req :: s_wait :: s_flush :: Nil = Enum(3)
   val state = RegInit(s_req)
 
-  when (reqq.io.deq.fire()) {
+  when (reqq.io.deq.fire) {
     check := reqq.io.deq.bits.check
     offset := reqq.io.deq.bits.offset
     startPos := 0.U
     state := Mux(reqq.io.deq.bits.check, s_wait, s_flush)
   }
 
-  when (calc.io.result.fire()) {
+  when (calc.io.result.fire) {
     csum := calc.io.result.bits
     state := s_flush
   }
 
-  when (io.stream.out.fire()) {
+  when (io.stream.out.fire) {
     startPos := nextStartPos
     when (io.stream.out.bits.last) { state := s_req }
   }
@@ -192,8 +192,8 @@ class ChecksumTest extends UnitTest {
   val rewriter = Module(new ChecksumRewrite(
     dataBits, data.length/shortsPerFlit))
 
-  val (inIdx, inDone) = Counter(rewriter.io.stream.in.fire(), dataVec.length)
-  val (outIdx, outDone) = Counter(rewriter.io.stream.out.fire(), expectedVec.length)
+  val (inIdx, inDone) = Counter(rewriter.io.stream.in.fire, dataVec.length)
+  val (outIdx, outDone) = Counter(rewriter.io.stream.out.fire, expectedVec.length)
 
   rewriter.io.req.valid := state === s_req
   rewriter.io.req.bits.check  := true.B
@@ -208,7 +208,7 @@ class ChecksumTest extends UnitTest {
   io.finished := state === s_done
 
   when (state === s_start && io.start) { state := s_req }
-  when (rewriter.io.req.fire()) { state := s_input }
+  when (rewriter.io.req.fire) { state := s_input }
   when (inDone) { state := s_output }
   when (outDone) { state := s_done }
 
@@ -308,7 +308,7 @@ class TCPChecksumOffload(dataBits: Int) extends Module {
   io.result.bits.checked := resultExpected
   csum.io.result.ready := state === s_result && resultExpected && io.result.ready
 
-  when (io.in.fire()) {
+  when (io.in.fire) {
     when (io.in.bits.last) {
       state := s_result
     } .elsewhen (state === s_header_in) {
@@ -321,7 +321,7 @@ class TCPChecksumOffload(dataBits: Int) extends Module {
     }
   }
 
-  when (csum.io.req.fire()) {
+  when (csum.io.req.fire) {
     headerIdx := 0.U
     state := s_header_csum
   }
@@ -333,7 +333,7 @@ class TCPChecksumOffload(dataBits: Int) extends Module {
     }
   }
 
-  when (io.result.fire()) {
+  when (io.result.fire) {
     headerIdx := 0.U
     resultExpected := false.B
     state := s_header_in
@@ -367,8 +367,8 @@ class ChecksumTCPVerify extends UnitTest {
 
   val offload = Module(new TCPChecksumOffload(NET_IF_WIDTH))
 
-  val (inIdx, inDone) = Counter(offload.io.in.fire(), dataWords.length)
-  val (resultIdx, resultDone) = Counter(offload.io.result.fire(), expectedResults.length)
+  val (inIdx, inDone) = Counter(offload.io.in.fire, dataWords.length)
+  val (resultIdx, resultDone) = Counter(offload.io.result.fire, expectedResults.length)
 
   offload.io.in.valid := inputValid
   offload.io.in.bits.data := dataWords(inIdx)

--- a/src/main/scala/DMA.scala
+++ b/src/main/scala/DMA.scala
@@ -99,8 +99,8 @@ class StreamReaderCore(nXacts: Int, outFlits: Int, maxBytes: Int)
     val rkeep = fullKeep >> roffset
     val first = Reg(Bool())
 
-    xactBusy := (xactBusy | Mux(tl.a.fire(), xactOnehot, 0.U)) &
-                    ~Mux(tl.d.fire() && edge.last(tl.d),
+    xactBusy := (xactBusy | Mux(tl.a.fire, xactOnehot, 0.U)) &
+                    ~Mux(tl.d.fire && edge.last(tl.d),
                           UIntToOH(tl.d.bits.source), 0.U)
 
     val helper = DecoupledHelper(tl.a.ready, io.alloc.ready)
@@ -130,7 +130,7 @@ class StreamReaderCore(nXacts: Int, outFlits: Int, maxBytes: Int)
     io.resp.valid := state === s_resp
     io.resp.bits := true.B
 
-    when (io.req.fire()) {
+    when (io.req.fire) {
       val req = io.req.bits
       val lastaddr = req.address + req.length
       val startword = req.address(addrBits-1, byteAddrBits)
@@ -149,7 +149,7 @@ class StreamReaderCore(nXacts: Int, outFlits: Int, maxBytes: Int)
       assert(req.length > 0.U, s"request length must be >0")
     }
 
-    when (tl.a.fire()) {
+    when (tl.a.fire) {
       val reqBytes = 1.U << reqSize
       sendaddr := sendaddr + reqBytes
       sendlen  := sendlen - reqBytes
@@ -169,7 +169,7 @@ class StreamReaderCore(nXacts: Int, outFlits: Int, maxBytes: Int)
       }
     }
 
-    when (io.resp.fire()) {
+    when (io.resp.fire) {
       state := s_idle
     }
   }
@@ -234,8 +234,8 @@ class StreamWriter(nXacts: Int, maxBytes: Int)
           (addrMerged(lgSize-1,0) === 0.U &&
             (bytesToSend >> lgSize.U) =/= 0.U) -> lgSize.U))
 
-    xactBusy := (xactBusy | Mux(tl.a.fire() && newBlock, xactOnehot, 0.U)) &
-                    ~Mux(tl.d.fire(), UIntToOH(tl.d.bits.source), 0.U)
+    xactBusy := (xactBusy | Mux(tl.a.fire && newBlock, xactOnehot, 0.U)) &
+                    ~Mux(tl.d.fire, UIntToOH(tl.d.bits.source), 0.U)
 
     val overhang = RegInit(0.U(dataBits.W))
     val sendTrail = bytesToSend <= extraBytes
@@ -270,7 +270,7 @@ class StreamWriter(nXacts: Int, maxBytes: Int)
     io.resp.valid := state === s_resp && !xactBusy.orR
     io.resp.bits := length
 
-    when (io.req.fire()) {
+    when (io.req.fire) {
       offset := 0.U
       baseAddr := io.req.bits.address
       length := io.req.bits.length
@@ -278,7 +278,7 @@ class StreamWriter(nXacts: Int, maxBytes: Int)
       state := s_data
     }
 
-    when (tl.a.fire()) {
+    when (tl.a.fire) {
       when (!newBlock) {
         beatsLeft := beatsLeft - 1.U
       } .elsewhen (reqSize > byteAddrBits.U) {
@@ -296,6 +296,6 @@ class StreamWriter(nXacts: Int, maxBytes: Int)
       when (bytesSent === bytesToSend) { state := s_resp }
     }
 
-    when (io.resp.fire()) { state := s_idle }
+    when (io.resp.fire) { state := s_idle }
   }
 }

--- a/src/main/scala/Limiter.scala
+++ b/src/main/scala/Limiter.scala
@@ -51,13 +51,13 @@ class RateLimiter[T <: Data](typ: T) extends Module {
 
   def uint_min(a: UInt, b: UInt) = Mux(a < b, a, b)
 
-  when (inc_trigger && io.out.fire()) {
+  when (inc_trigger && io.out.fire) {
     val next_tokens = tokens +& (io.settings.inc - 1.U)
     tokens := uint_min(next_tokens, io.settings.size)
   } .elsewhen (inc_trigger) {
     val next_tokens = tokens +& io.settings.inc
     tokens := uint_min(next_tokens, io.settings.size)
-  } .elsewhen (io.out.fire()) {
+  } .elsewhen (io.out.fire) {
     tokens := tokens - 1.U
   }
 }
@@ -89,8 +89,8 @@ class RateLimiterTest extends UnitTest {
   limiter.io.settings.period := 3.U
   limiter.io.settings.size := 2.U
 
-  val (sendCount, sendDone) = Counter(limiter.io.in.fire(), nFlits)
-  val (recvCount, recvDone) = Counter(limiter.io.out.fire(), nFlits)
+  val (sendCount, sendDone) = Counter(limiter.io.in.fire, nFlits)
+  val (recvCount, recvDone) = Counter(limiter.io.out.fire, nFlits)
 
   when (io.start && !started) {
     started := true.B

--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -92,7 +92,7 @@ trait IceNicControllerModule extends HasRegMap with HasNICParameters {
   require(qDepth < (1 << 8))
 
   def queueCount[T <: Data](qio: QueueIO[T], depth: Int): UInt =
-    TwoWayCounter(qio.enq.fire(), qio.deq.fire(), depth)
+    TwoWayCounter(qio.enq.fire, qio.deq.fire, depth)
 
   // hold (len, addr) of packets that we need to send out
   val sendReqQueue  = Module(new HellaQueue(qDepth)(UInt(NET_IF_WIDTH.W)))
@@ -101,7 +101,7 @@ trait IceNicControllerModule extends HasRegMap with HasNICParameters {
   val recvReqQueue  = Module(new HellaQueue(qDepth)(UInt(NET_IF_WIDTH.W)))
   val recvReqCount  = queueCount(recvReqQueue.io, qDepth)
   // count number of sends completed
-  val sendCompCount = TwoWayCounter(io.send.comp.fire(), sendCompDown, qDepth)
+  val sendCompCount = TwoWayCounter(io.send.comp.fire, sendCompDown, qDepth)
   // hold length of received packets
   val recvCompQueue = Module(new HellaQueue(qDepth)(UInt(NET_LEN_BITS.W)))
   val recvCompCount = queueCount(recvCompQueue.io, qDepth)
@@ -257,8 +257,8 @@ class IceNicWriter(implicit p: Parameters) extends NICLazyModule {
 
     io.recv.comp <> writer.module.io.resp
 
-    when(io.recv.req.fire()) { streaming := true.B }
-    when(io.in.fire() && io.in.bits.last) { streaming := false.B }
+    when(io.recv.req.fire) { streaming := true.B }
+    when(io.in.fire && io.in.bits.last) { streaming := false.B }
   }
 }
 

--- a/src/main/scala/NICTests.scala
+++ b/src/main/scala/NICTests.scala
@@ -55,7 +55,7 @@ class IceNicTestSendDriver(
     val memIdx = Reg(UInt(log2Ceil(totalMemCount).W))
 
     val outSend = TwoWayCounter(
-      io.send.req.fire(), io.send.comp.fire(), sendReqs.size)
+      io.send.req.fire, io.send.comp.fire, sendReqs.size)
 
     val writeAddr = sendReqAddrVec(reqIdx) + (memIdx << byteAddrBits.U)
     val writeData = sendDataVec(sendReqBase(reqIdx) + memIdx)
@@ -80,9 +80,9 @@ class IceNicTestSendDriver(
       state := s_write_req
     }
 
-    when (tl.a.fire()) { state := s_write_resp }
+    when (tl.a.fire) { state := s_write_resp }
 
-    when (tl.d.fire()) {
+    when (tl.d.fire) {
       memIdx := memIdx + 1.U
       state := s_write_req
 
@@ -96,7 +96,7 @@ class IceNicTestSendDriver(
       }
     }
 
-    when (io.send.req.fire()) {
+    when (io.send.req.fire) {
       reqIdx := reqIdx + 1.U
       when (reqIdx === (sendReqs.size - 1).U) {
         reqIdx := 0.U
@@ -134,7 +134,7 @@ class IceNicTestRecvDriver(recvReqs: Seq[Int], recvData: Seq[BigInt])
     val memIdx = Reg(UInt(log2Ceil(recvData.size).W))
 
     val outRecv = TwoWayCounter(
-      io.recv.req.fire(), io.recv.comp.fire(), recvReqVec.size)
+      io.recv.req.fire, io.recv.comp.fire, recvReqVec.size)
 
     tl.a.valid := state === s_check_req
     tl.a.bits := edge.Get(
@@ -155,7 +155,7 @@ class IceNicTestRecvDriver(recvReqs: Seq[Int], recvData: Seq[BigInt])
       state := s_recv
     }
 
-    when (io.recv.req.fire()) {
+    when (io.recv.req.fire) {
       reqIdx := reqIdx + 1.U
       when (reqIdx === (recvReqVec.size - 1).U) {
         reqIdx := 0.U
@@ -271,8 +271,8 @@ class IceNicSendTest(implicit p: Parameters) extends NICLazyModule {
     val sendReqVec = VecInit(sendReqs.map { case (start, len, part) =>
       Cat(part.B, len.U(15.W), start.U(48.W))
     })
-    val (sendReqIdx, sendReqDone) = Counter(sendPathIO.send.req.fire(), sendReqs.size)
-    val (sendCompIdx, sendCompDone) = Counter(sendPathIO.send.comp.fire(), sendReqs.size)
+    val (sendReqIdx, sendReqDone) = Counter(sendPathIO.send.req.fire, sendReqs.size)
+    val (sendCompIdx, sendCompDone) = Counter(sendPathIO.send.comp.fire, sendReqs.size)
 
     val started = RegInit(false.B)
     val requesting = RegInit(false.B)
@@ -356,14 +356,14 @@ class IceNicTest(implicit p: Parameters) extends NICLazyModule {
     val cycle_count = Reg(UInt(64.W))
     val recv_count = Reg(UInt(1.W))
 
-    when (count_state === count_start && sendPath.module.io.send.req.fire()) {
+    when (count_state === count_start && sendPath.module.io.send.req.fire) {
       count_state := count_up
       cycle_count := 0.U
       recv_count := 1.U
     }
     when (count_state === count_up) {
       cycle_count := cycle_count + 1.U
-      when (recvPath.module.io.recv.comp.fire()) {
+      when (recvPath.module.io.recv.comp.fire) {
         recv_count := recv_count - 1.U
         when (recv_count === 0.U) { count_state := count_print }
       }
@@ -415,14 +415,14 @@ class MisalignedTestDriver(implicit p: Parameters) extends Module {
        s_outdata1 :: s_outdata2 :: s_indata :: s_done :: Nil) = Enum(9)
   val state = RegInit(s_start)
 
-  val (recvReqIdx, recvReqDone) = Counter(io.recv.req.fire(), 2)
-  val (recvCompIdx, recvCompDone) = Counter(io.recv.comp.fire(), 2)
+  val (recvReqIdx, recvReqDone) = Counter(io.recv.req.fire, 2)
+  val (recvCompIdx, recvCompDone) = Counter(io.recv.comp.fire, 2)
 
   val (outIdx1, outDone1) = Counter(
     state === s_outdata1 && io.net.out.ready, outData1.size)
   val (outIdx2, outDone2) = Counter(
     state === s_outdata2 && io.net.out.ready, outData2.size)
-  val (inIdx, inDone) = Counter(io.net.in.fire(), expData.size)
+  val (inIdx, inDone) = Counter(io.net.in.fire, expData.size)
 
   val outBits1 = Wire(new StreamChannel(NET_IF_WIDTH))
   outBits1.data := outData1(outIdx1)
@@ -457,7 +457,7 @@ class MisalignedTestDriver(implicit p: Parameters) extends Module {
 
   when (recvCompDone) { state := s_sendreq }
 
-  when (io.send.req.fire()) { state := s_indata }
+  when (io.send.req.fire) { state := s_indata }
 
   when (inDone) { state := s_done }
 

--- a/src/main/scala/Pauser.scala
+++ b/src/main/scala/Pauser.scala
@@ -79,7 +79,7 @@ class Pauser(creditInit: Int, nBuckets: Int) extends Module
 
   when (outPaused) { outPauseTimer := outPauseTimer - 1.U }
 
-  when (io.int.in.fire()) {
+  when (io.int.in.fire) {
     val data = io.int.in.bits.data
 
     switch (state) {
@@ -105,7 +105,7 @@ class Pauser(creditInit: Int, nBuckets: Int) extends Module
   }
 
   for (i <- 0 until nBuckets) {
-    credits(i) := credits(i) - io.int.in.fire() + io.in_free(i)
+    credits(i) := credits(i) - io.int.in.fire + io.in_free(i)
   }
 
   val arb = Module(new PacketArbiter(2))
@@ -117,7 +117,7 @@ class Pauser(creditInit: Int, nBuckets: Int) extends Module
   val outVec = VecInit(outHeader.toWords() :+ Cat(
     htons(io.settings.quanta), htons(PAUSE_CTRL.U(16.W))))
   val sendPause = RegInit(false.B)
-  val (outIdx, outDone) = Counter(arb.io.in(0).fire(), outVec.size)
+  val (outIdx, outDone) = Counter(arb.io.in(0).fire, outVec.size)
 
   arb.io.in(0).valid := sendPause
   arb.io.in(0).bits.data := outVec(outIdx)
@@ -145,7 +145,7 @@ class Pauser(creditInit: Int, nBuckets: Int) extends Module
   arb.io.in(1).bits := io.int.out.bits
   io.int.out.ready := canForward && arb.io.in(1).ready
 
-  when (arb.io.in(1).fire()) {
+  when (arb.io.in(1).fire) {
     when (!outInProgress) { outInProgress := true.B }
     when (arb.io.in(1).bits.last) { outInProgress := false.B }
   }
@@ -210,11 +210,11 @@ class PauserTest extends UnitTest {
   val started = RegInit(false.B)
 
   val sending = RegInit(false.B)
-  val (sendIdx, sendPktDone) = Counter(lcomplex.io.int.out.fire(), pktData.size)
+  val (sendIdx, sendPktDone) = Counter(lcomplex.io.int.out.fire, pktData.size)
   val (sendPhase, sendDone) = Counter(sendPktDone, nPackets)
 
   val receiving = RegInit(false.B)
-  val (recvIdx, recvPktDone) = Counter(lcomplex.io.int.in.fire(), pktData.size)
+  val (recvIdx, recvPktDone) = Counter(lcomplex.io.int.in.fire, pktData.size)
   val (recvPhase, recvDone) = Counter(recvPktDone, nPackets)
 
   lcomplex.io.int.out.valid := sending

--- a/src/main/scala/TCAM.scala
+++ b/src/main/scala/TCAM.scala
@@ -53,7 +53,7 @@ class TCAMModule(outer: TCAM) extends LazyModuleImp(outer) {
     TLMessages.AccessAck, TLMessages.AccessAckData)
   tl.d.bits.data := Mux(regsel, maskArr(wordaddr), dataArr(wordaddr))
 
-  when (acq.fire() && edge.hasData(acq.bits)) {
+  when (acq.fire && edge.hasData(acq.bits)) {
     when (regsel) {
       maskArr(wordaddr) := acq.bits.data(outer.dataBits - 1, 0)
     } .otherwise {

--- a/src/main/scala/Tap.scala
+++ b/src/main/scala/Tap.scala
@@ -98,7 +98,7 @@ class NetworkTap[T <: Data](
   }
 
   val headerFire = state === s_output_header && selectedReady
-  val bodyFire = state === s_forward_body && io.inflow.fire()
+  val bodyFire = state === s_forward_body && io.inflow.fire
 
   when (headerFire) {
     headerIdx := headerIdx + 1.U

--- a/src/main/scala/TestUtils.scala
+++ b/src/main/scala/TestUtils.scala
@@ -35,7 +35,7 @@ class PacketGen(lengths: Seq[Int], genData: Seq[BigInt]) extends Module {
     dataIdx := 0.U
   }
 
-  when (io.out.fire()) {
+  when (io.out.fire) {
     dataIdx := dataIdx + 1.U
     pktOffset := pktOffset + 1.U
     when (io.out.bits.last) {
@@ -67,7 +67,7 @@ class PacketCheck(
   val checkKeepVec = VecInit(checkKeep.map(_.U(NET_IF_BYTES.W)))
   val checkLastVec = VecInit(checkLast.map(_.B))
 
-  val (checkIdx, checkDone) = Counter(io.in.fire(), checkDataVec.length)
+  val (checkIdx, checkDone) = Counter(io.in.fire, checkDataVec.length)
 
   val finished = RegInit(false.B)
 


### PR DESCRIPTION
## Purpose

### Why is this change being made?
fix these Scala compile warnings:
```
[warn] icenet/src/main/scala/Aligner.scala:44:12: method fire in class AddMethodsToReadyValid is deprecated (since Chisel 3.5): Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead
[warn]   when (io.in.fire() && io.out.fire()) {
[warn]            ^
```
and many similar

### Type of change
- Paying Off Technical Debt


## Scope

### What was changed?
`.fire` remove `()`

### Breaking changes to APIs or data formats
<!-- Describe any changes to interfaces and steps for migrating. -->

### What should be reviewed
<!-- @-mention individual reviewers and indicate what you expect from their review -->


## Risk

### What are the potential consequences of this change?
<!-- Describe any positive or negative effects these changes may have on build health or people's workflows -->

<!-- Describe the impact of this change on build times, test run times, and license usage -->

### How this was tested or validated
`make prelude`

### Technical debt added
there are many more warnings we can take down for spring cleaning