### PR TITLE
Scala warnings: add ': Unit =' explicit return type

### DIFF
--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -544,7 +544,7 @@ trait CanHavePeripheryIceNIC { this: BaseSubsystem =>
 }
 
 object NicLoopback {
-  def connect(net: Option[NICIOvonly], nicConf: Option[NICConfig], qDepth: Int, latency: Int = 10) {
+  def connect(net: Option[NICIOvonly], nicConf: Option[NICConfig], qDepth: Int, latency: Int = 10): Unit = {
     net.foreach { netio =>
       import PauseConsts.BT_PER_QUANTA
       val packetWords  = nicConf.get.packetMaxBytes / NET_IF_BYTES
@@ -571,7 +571,7 @@ object NicLoopback {
     }
   }
 
-  def connect(net: Option[NICIOvonly], nicConf: Option[NICConfig]) {
+  def connect(net: Option[NICIOvonly], nicConf: Option[NICConfig]): Unit = {
     net.foreach { netio =>
       val packetWords = nicConf.get.packetMaxBytes / NET_IF_BYTES
       NicLoopback.connect(net, nicConf, 4 * packetWords)
@@ -580,7 +580,7 @@ object NicLoopback {
 }
 
 object SimNetwork {
-  def connect(net: Option[NICIOvonly], clock: Clock, reset: Bool) {
+  def connect(net: Option[NICIOvonly], clock: Clock, reset: Bool): Unit = {
     net.foreach { netio =>
       val sim = Module(new SimNetwork)
       sim.io.clock := clock


### PR DESCRIPTION
## Purpose

### Why is this change being made?
fix these Scala compile warnings:
```
[warn] icenet/src/main/scala/NIC.scala:547:100: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `connect`'s return type
[warn]   def connect(net: Option[NICIOvonly], nicConf: Option[NICConfig], qDepth: Int, latency: Int = 10) {
[warn]                                                                                                    ^
[warn] icenet/src/main/scala/NIC.scala:574:68: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `connect`'s return type
[warn]   def connect(net: Option[NICIOvonly], nicConf: Option[NICConfig]) {
[warn]                                                                    ^
[warn] icenet/src/main/scala/NIC.scala:583:67: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `connect`'s return type
[warn]   def connect(net: Option[NICIOvonly], clock: Clock, reset: Bool) {
[warn]                                                                   ^
```

### Type of change
- Paying Off Technical Debt


## Scope

### What was changed?
`def {` add `: Unit =`

### Breaking changes to APIs or data formats
<!-- Describe any changes to interfaces and steps for migrating. -->

### What should be reviewed
<!-- @-mention individual reviewers and indicate what you expect from their review -->


## Risk

### What are the potential consequences of this change?
<!-- Describe any positive or negative effects these changes may have on build health or people's workflows -->

<!-- Describe the impact of this change on build times, test run times, and license usage -->

### How this was tested or validated
`make prelude`

### Technical debt added
there are many more warnings we can take down for spring cleaning