### PR TITLE
Scala warnings: scalafix unused imports

### DIFF
--- a/src/main/scala/Buffer.scala
+++ b/src/main/scala/Buffer.scala
@@ -4,7 +4,6 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.unittest.UnitTest
 import freechips.rocketchip.util.TwoWayCounter
-import scala.util.Random
 import testchipip.{StreamIO, StreamChannel}
 import IceNetConsts._
 

--- a/src/main/scala/Limiter.scala
+++ b/src/main/scala/Limiter.scala
@@ -3,7 +3,6 @@ package icenet
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.unittest.UnitTest
-import testchipip.SerialIO
 import IceNetConsts._
 
 class RateLimiterSettings extends Bundle {

--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.regmapper.{HasRegMap, RegField}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import freechips.rocketchip.prci.ClockSinkDomain
-import testchipip.{ClockedIO, StreamChannel, StreamIO, TLHelper}
+import testchipip.{ClockedIO, StreamChannel, StreamIO}
 import IceNetConsts._
 
 /** @inBufFlits How many flits in the input buffer(s)

--- a/src/main/scala/Pauser.scala
+++ b/src/main/scala/Pauser.scala
@@ -2,7 +2,6 @@ package icenet
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.{HellaPeekingArbiter}
 import freechips.rocketchip.unittest.UnitTest
 import testchipip.{StreamIO, StreamChannel}
 import IceNetConsts._

--- a/src/main/scala/Tap.scala
+++ b/src/main/scala/Tap.scala
@@ -3,8 +3,6 @@ package icenet
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.unittest.UnitTest
-import freechips.rocketchip.util.UIntIsOneOf
-import scala.math.max
 import testchipip._
 import IceNetConsts._
 


### PR DESCRIPTION
### Why is this change being made?
fix these Scala compile warnings:
```
[warn] icenet/src/main/scala/Buffer.scala:7:19: Unused import
[warn] import scala.util.Random
[warn]                   ^
[warn] icenet/src/main/scala/Limiter.scala:6:19: Unused import
[warn] import testchipip.SerialIO
[warn]                   ^
[warn] icenet/src/main/scala/NIC.scala:14:56: Unused import
[warn] import testchipip.{ClockedIO, StreamChannel, StreamIO, TLHelper}
[warn]                                                        ^
[warn] icenet/src/main/scala/Pauser.scala:5:35: Unused import
[warn] import freechips.rocketchip.util.{HellaPeekingArbiter}
[warn]                                   ^
[warn] icenet/src/main/scala/Tap.scala:6:34: Unused import
[warn] import freechips.rocketchip.util.UIntIsOneOf
[warn]                                  ^
[warn] icenet/src/main/scala/Tap.scala:7:19: Unused import
[warn] import scala.math.max
[warn]                   ^
```

### Type of change
- Paying Off Technical Debt

### What was changed?
https://github.com/sifive/federation/pull/31054

### How this was tested or validated
`make prelude`