### PR TITLE
Handle Cat moving from chisel3.util to chisel3

### DIFF
--- a/src/main/scala/Aligner.scala
+++ b/src/main/scala/Aligner.scala
@@ -1,7 +1,7 @@
 package icenet
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, _}
 import freechips.rocketchip.unittest.UnitTest
 import testchipip.StreamIO
 import IceNetConsts._

--- a/src/main/scala/Checksum.scala
+++ b/src/main/scala/Checksum.scala
@@ -1,7 +1,7 @@
 package icenet
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, _}
 import freechips.rocketchip.unittest.UnitTest
 import freechips.rocketchip.util.{DecoupledHelper, UIntIsOneOf}
 import testchipip.{StreamIO, StreamChannel}

--- a/src/main/scala/DMA.scala
+++ b/src/main/scala/DMA.scala
@@ -1,7 +1,7 @@
 package icenet
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, _}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp, IdRange}
 import freechips.rocketchip.util.DecoupledHelper

--- a/src/main/scala/Headers.scala
+++ b/src/main/scala/Headers.scala
@@ -1,7 +1,7 @@
 package icenet
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, _}
 import IceNetConsts._
 
 object NetworkHelpers {

--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -1,7 +1,7 @@
 package icenet
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, _}
 import freechips.rocketchip.subsystem.{BaseSubsystem, FBUS, PBUS, TLBusWrapperLocation}
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/NICTests.scala
+++ b/src/main/scala/NICTests.scala
@@ -1,7 +1,7 @@
 package icenet
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, _}
 
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.devices.tilelink.TLROM

--- a/src/main/scala/Pauser.scala
+++ b/src/main/scala/Pauser.scala
@@ -1,7 +1,7 @@
 package icenet
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, _}
 import freechips.rocketchip.unittest.UnitTest
 import testchipip.{StreamIO, StreamChannel}
 import IceNetConsts._

--- a/src/main/scala/Tap.scala
+++ b/src/main/scala/Tap.scala
@@ -1,7 +1,7 @@
 package icenet
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, _}
 import freechips.rocketchip.unittest.UnitTest
 import testchipip._
 import IceNetConsts._


### PR DESCRIPTION
We specify the import in chisel3.util so that this code will compile in both Chisel 3.6 and earlier versions.

Deal with the move in https://github.com/chipsalliance/chisel/pull/3062, see https://github.com/chipsalliance/chisel/pull/3075#issuecomment-1468996253 for techniques used.