### PR TITLE
masterWhere panda backport

### DIFF
--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -6,6 +6,7 @@ import freechips.rocketchip.subsystem.{BaseSubsystem, FBUS, PBUS, TLBusWrapperLo
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.ecc.HasImplicitErrorReportReducerNexusNode
+import freechips.rocketchip.interconnect.BusWrapper
 import freechips.rocketchip.regmapper.{HasRegMap, RegField}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -34,7 +35,7 @@ case class NICConfig(
 )
 
 case class NICAttachParams(
-  masterWhere: TLBusWrapperLocation = FBUS,
+  masterWhere: Location[BusWrapper] = FBUS,
   slaveWhere:  TLBusWrapperLocation = PBUS,
 )
 


### PR DESCRIPTION
This change is required so that the icenet submodule version used by the release_generator_panda branch stays compatible.